### PR TITLE
fix two buffer overflow vulnerabilities

### DIFF
--- a/library.c
+++ b/library.c
@@ -13,7 +13,12 @@
 char *macosRunComm(char *command){
     //Move input command to static char array
     char toexec[1000];
-    strcpy(toexec, command);
+    if (strlen(command) < 1000)
+        strcpy(toexec, command);
+    else {
+        puts("Error - command is too large.");
+        exit(1);
+    }
     char commout[1000];
     //move from static to dynamic to mitigate issue
     sprintf(commout, "%s", toexec);
@@ -40,7 +45,12 @@ int macosRunGetExit(char *command){
     //redirect stdout and stderr, echo process exit code to stdout
     char *com2 = " >/dev/null 2>/dev/null; echo $?";
     char com1[2400];
-    strcpy(com1, command);
+    if (strlen(command) < 2400)
+        strcpy(com1, command);
+    else {
+        puts("Error - command is too large.");
+        exit(1);
+    }
     char commout[2400];
     sprintf(commout, "%s %s", com1, com2);
     char *com = commout;


### PR DESCRIPTION
In the man page of strcpy, there is a Security Considerations section where it states that a buffer overflow exploit can occur when using strcpy. In both the macosRunComm() function and macosRunGetExit() function in iLibX, strcpy() is used without checking the command string's size, which may exceed toexec's or com1's size and overwrite other memory.